### PR TITLE
feat(objectDoesMatch): provide mongo-style comparison search operators

### DIFF
--- a/controllers/objectDoesMatch.js
+++ b/controllers/objectDoesMatch.js
@@ -1,12 +1,61 @@
 // Compares an object to another
 
+const OPERATORS_COMPARISON = [
+  '$eq',
+  '$gt',
+  '$gte',
+  '$lt',
+  '$lte',
+  '$ne',
+];
+
 module.exports = (query, obj) => {
   let match = true;
   for (let key in query) {
-    if (obj[key] !== query[key]) {
-      match = false;
-      break;
+    const criteria = query[key];
+    if (typeof criteria === 'object') {
+      match = compareCriteria(criteria, obj[key]);
+      if (!match) break;
+    } else {
+      if (obj[key] !== query[key]) {
+        match = false;
+        break;
+      }
     }
   }
   return match;
 };
+
+const compareCriteria = (criteria, test) => {
+  let match = true;
+  for (const [ operator, value ] of Object.entries(criteria)) {
+    match = compareValue(operator, value, test);
+    if (!match) break;
+  }
+  return match;
+}
+
+const compareValue = (operator, value, test) => {
+  if (!OPERATORS_COMPARISON.includes(operator)) {
+    return false;
+  }
+  if (operator === '$eq' && test === value) {
+    return true;
+  }
+  if (operator === '$gt' && test > value) {
+    return true;
+  }
+  if (operator === '$gte' && test >= value) {
+    return true;
+  }
+  if (operator === '$lt' && test < value) {
+    return true;
+  }
+  if (operator === '$lte' && test <= value) {
+    return true;
+  }
+  if (operator === '$ne' && test !== value) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Stein can search only with equals [search param](https://docs.steinhq.com/search-data), such as
```
search = {
  "registered_date": "2019-10-01"
}
```
This PR provides a functionality to search using [MongoDB-style Comparison Query Operators](https://docs.mongodb.com/manual/reference/operator/query-comparison/) such as
```
search = {
  "registered_date": {
    "$gte": "2019-10-01",
    "$lt": "2019-11-01",
  },
}
```
This way we can have more expressive search functionality.

Edit: now also supports [Logical Query Operators](https://docs.mongodb.com/manual/reference/operator/query-logical/) such as
```
search = {
  "$or": [
    {"role":"admin"},
    {"department":"finance"}
  ],
}
```