### PR TITLE
feat(apiRoutes): direct access to sheets

### DIFF
--- a/apiRoutes.js
+++ b/apiRoutes.js
@@ -12,12 +12,14 @@ module.exports = app => {
     URL structure: /?search={"key":"value", ...}
   */
   app.get("/v1/storages/:id/:sheet", controllers.storage.readSheet);
+  app.get("/v1/sheets/:googleId/:sheet", controllers.storage.readSheet);
 
   /*
     Append a new row
     POST body: [{row object}, ...]
   */
   app.post("/v1/storages/:id/:sheet", controllers.storage.appendRow);
+  app.post("/v1/sheets/:googleId/:sheet", controllers.storage.appendRow);
 
   /*
     Edit row(s)
@@ -28,6 +30,7 @@ module.exports = app => {
     }
   */
   app.put("/v1/storages/:id/:sheet", controllers.storage.editRow);
+  app.put("/v1/sheets/:googleId/:sheet", controllers.storage.editRow);
 
   /*
     Delete row(s)
@@ -37,4 +40,5 @@ module.exports = app => {
     }
   */
   app.delete("/v1/storages/:id/:sheet", controllers.storage.deleteRow);
+  app.delete("/v1/sheets/:googleId/:sheet", controllers.storage.deleteRow);
 };

--- a/controllers/appendRow.js
+++ b/controllers/appendRow.js
@@ -13,18 +13,11 @@ module.exports = (req, res, next) => {
       authConfig.google.clientSecret
     );
 
-  // Find spreadsheet in storage, then refresh the token of owner
-  Storage.findById(req.params.id)
-    .then(result => {
-      // Refresh user's access token if necessary
-      User.refreshAccessCode(result.userGoogleId).then(validatedUser => {
-        // Pass the valid user and result to the function which reads and parses the sheets, so as to supply the googleId of the sheet with the appropriate OAuth details.
-        appendRow(validatedUser, result);
-      });
-    })
-    .catch(err => {
-      res.send(err);
-    });
+  User.refreshAccessCode(res.locals.sheetIdDbResult.userGoogleId).then(
+    validatedUser => {
+      appendRow(validatedUser, res.locals.sheetIdDbResult);
+    }
+  );
 
   const appendRow = (validatedUser, queriedSheetDetails) => {
     oAuth2Client.setCredentials({

--- a/controllers/checkAuth.js
+++ b/controllers/checkAuth.js
@@ -1,4 +1,5 @@
 const Storage = require("../models/storage"),
+  User = require("../models/user"),
   auth = require("basic-auth");
 
 const apiNotFoundError = { code: 404, message: "API does not exist" };
@@ -48,6 +49,16 @@ function getStorage(req, res) {
   // If the storage had been already fetched and set by some other middleware, no need to do that again
   if (res.locals.sheetIdDbResult) {
     return Promise.resolve(res.locals.sheetIdDbResult);
+  }
+
+  if (req.params.googleId) {
+    return User.findOne({ email: process.env.STEIN_DEFAULT_EMAIL })
+      .then(result => {
+        return {
+          googleId: req.params.googleId,
+          userGoogleId: result.googleId,
+        };
+      });
   }
 
   return Storage.findById(req.params.id);


### PR DESCRIPTION
This PR provides a way to access Google Sheets directly using sheet's googleId without adding it first to the sheet via Stein dashboard.

Usually we access this endpoint to access registered sheet.
```
/v1/storages/:id/:sheet
```
If we have sheet `https://docs.google.com/spreadsheets/d/:googleId/edit` we can access it to this endpoint.
```
/v1/sheets/:googleId/:sheet
```

The user that accessing the sheet is set in env `STEIN_DEFAULT_EMAIL=example@email.com`. This email needs to be logged in to Stein at least once and have access to the sheet.